### PR TITLE
Fix regex pattern by trimming slashes

### DIFF
--- a/template/admin/resource/performs_validation.go
+++ b/template/admin/resource/performs_validation.go
@@ -68,7 +68,7 @@ func (p *Template) Validator(rules []rule.Rule, data map[string]interface{}) err
 			}
 		case "regexp":
 			if fieldValue, ok := fieldValue.(string); ok {
-				re := regexp.MustCompile(rule.Pattern)
+				re := regexp.MustCompile(strings.Trim(rule.Pattern, "/"))
 				if !re.MatchString(fieldValue) {
 					errMsg := rule.Message
 					if errMsg != "" {


### PR DESCRIPTION
Trimmed slashes from the regex pattern before compilation.